### PR TITLE
Fix Vercel build for Parcel app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    }
+  ],
+  "routes": [
+    {"src": "/(.*)", "dest": "index.html"}
+  ]
+}


### PR DESCRIPTION
## Summary
- configure `.gitignore` for node_modules and dist
- add `vercel.json` so Vercel treats the project as a static build

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: `node_modules/.bin/parcel: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd578520832a9de8391666f73e40